### PR TITLE
adopt initial project governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,7 +33,7 @@ Our governance builds on top of definitions from other documents, review the fol
 While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
-* A vote begins when a PR that has the `/vote` comment.
+* A vote begins when someone adds a PR comment containing the `/vote` command.
 * A simple majority of eligible votes decides the vote outcome.
 * A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot on the GitHub PR, referring to the most recent commit when the vote is created. If there is any further commit to the PR, a new vote must be created.
 * No single company should have more than six eligible voters. It is the responsibility of each company to determine which affiliated maintainers are the eligible voters.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,17 +6,17 @@ K8sGateway is dedicated to building a feature-rich, fast and flexible ingress co
 
 The K8sGateway project embraces the following values:
 
-- Openness: Communication and decision-making happens in the open and is discoverable for future
+* Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
-- Fairness: All stakeholders have the opportunity to provide feedback and submit
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
-- Community over Product or Company: Sustaining and growing our community takes
+* Community over Product or Company: Sustaining and growing our community takes
   priority over shipping code or sponsors' organizational goals.  Each
   contributor participates in the project as an individual.
-- Inclusivity: We innovate through different perspectives and skill sets, which
+* Inclusivity: We innovate through different perspectives and skill sets, which
   can only be accomplished in a welcoming and respectful environment.
-- Participation: Responsibilities within the project are earned through
+* Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
@@ -24,20 +24,20 @@ The K8sGateway project embraces the following values:
 
 Our governance builds on top of definitions from other documents, review the following files for relevant information:
 
-- [ROLES.md](./ROLES.md) for the different roles with the project.
-- [MAINTAINERS.md](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
-- [Code of Conduct](./CODE-OF-CONDUCT.md) for our code of conduct.
+* [ROLES.md](./ROLES.md) for the different roles with the project.
+* [MAINTAINERS.md](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
+* [Code of Conduct](./CODE-OF-CONDUCT.md) for our code of conduct.
 
 ## Voting
 
 While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
-- A vote begins when an issue with the label `call to vote` is submitted.
-- A simple majority decides the vote outcome.
-- A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
-- No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
-- Voting must be open for at least one week or until the required threshold is met.
+* A vote begins when an issue with the label `call to vote` is submitted.
+* A simple majority decides the vote outcome.
+* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
+* No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
+* Voting must be open for at least one week or until the required threshold is met.
 
 ## Changes to governance
 
@@ -46,8 +46,8 @@ TODO: Enumerate what, precisely, constitutes a change in governance. I think it'
 -->
 All changes to our governance model require a vote by the maintainers. The proposed change will be submitted as a PR against the K8sGateway community repository. Voting will proceed according to the rules established for simple conflict resolution, with the sole exception being the threshold for acceptance.
 
-- Any change requires a 2/3 super majority to be accepted.
+* Any change requires a 2/3 super majority to be accepted.
 
 ## Vendor-neutrality
 
-K8sGateway is committed to [vendor-neutrality](https://contribute.cncf.io/maintainers/community/vendor-neutrality/). Our governance process has been designed to limit the influence of individual companies in furtherance of this goal.
+K8sGateway is committed to [vendor-neutrality](https://contribute.cncf.io/maintainers/community/vendor-neutrality/). Our governance process has been designed to limit the influence of individual companies in furtherance of this goal. If you have concerns about the vendor-neutrality of the project please open an issue in this repository or join our [community meeting](https://calendar.google.com/calendar/u/1?cid=ZDI0MzgzOWExMGYwMzAxZjVkYjQ0YTU0NmQ1MDJmODA5YTBjZDcwZGI4ZTBhZGNhMzIwYWRlZjJkOTQ4MzU5Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) to discuss.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -37,7 +37,7 @@ periodically the Maintainers may need to vote on specific actions or changes. Th
 * A simple majority of eligible votes decides the vote outcome.
 * A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on a specific "call to vote" comment of the GitHub PR, referring to the most recent commit when the comment is entered. If there is any further commit to the PR, a new vote must be called to refer to the new commit.
 * No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
-* Voting must be open for at least one week or until the required threshold is met.
+* Voting must be open for at least one week or until the required threshold is met, whichever is sooner.
 
 ## Changes to governance
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ While most business in K8sGateway is conducted by "[lazy consensus](https://comm
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
 * A vote begins when a PR that has a comment with the label `up-for-vote` is submitted.
-* A simple majority decides the vote outcome.
+* A simple majority of eligible votes decides the vote outcome.
 * A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
 * No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
 * Voting must be open for at least one week or until the required threshold is met.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ periodically the Maintainers may need to vote on specific actions or changes. Th
 
 * A vote begins when a PR that has a comment with the label `up-for-vote` is submitted.
 * A simple majority of eligible votes decides the vote outcome.
-* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
+* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on a specific "call to vote" comment of the GitHub PR, referring to the most recent commit when the comment is entered. If there is any further commit to the PR, a new vote must be called to refer to the new commit.
 * No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
 * Voting must be open for at least one week or until the required threshold is met.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ periodically the Maintainers may need to vote on specific actions or changes. Th
 
 * A vote begins when a PR that has the `/vote` comment.
 * A simple majority of eligible votes decides the vote outcome.
-* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot of the GitHub PR, referring to the most recent commit when the vote is created. If there is any further commit to the PR, a new vote must be created.
+* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot on the GitHub PR, referring to the most recent commit when the vote is created. If there is any further commit to the PR, a new vote must be created.
 * No single company should have more than six eligible voters. It is the responsibility of each company to determine which affiliated maintainers are the eligible voters.
 * Voting must be open for at least one week or until the required threshold is met, whichever is sooner.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,10 +33,10 @@ Our governance builds on top of definitions from other documents, review the fol
 While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
-* A vote begins when a PR that has a comment with the label `up-for-vote` is submitted.
+* A vote begins when a PR that has the `/vote` comment.
 * A simple majority of eligible votes decides the vote outcome.
-* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on a specific "call to vote" comment of the GitHub PR, referring to the most recent commit when the comment is entered. If there is any further commit to the PR, a new vote must be called to refer to the new commit.
-* No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
+* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot of the GitHub PR, referring to the most recent commit when the vote is created. If there is any further commit to the PR, a new vote must be created.
+* No single company should have more than six eligible voters. It is the responsibility of each company to determine which affiliated maintainers are the eligible voters.
 * Voting must be open for at least one week or until the required threshold is met, whichever is sooner.
 
 ## Changes to governance

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,7 +33,7 @@ Our governance builds on top of definitions from other documents, review the fol
 While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
-* A vote begins when an issue with the label `call to vote` is submitted.
+* A vote begins when a PR that has a comment with the label `up-for-vote` is submitted.
 * A simple majority decides the vote outcome.
 * A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
 * No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,25 +24,25 @@ The K8sGateway project embraces the following values:
 
 Our governance builds on top of definitions from other documents, review the following files for relevant information:
 
-- [`ROLES.md`](./ROLES.md) for the different roles with the project.
-- [`MAINTAINERS.md`](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
+- [ROLES.md](./ROLES.md) for the different roles with the project.
+- [MAINTAINERS.md](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
 - [Code of Conduct](./CODE-OF-CONDUCT.md) for our code of conduct.
 
+## Voting
 
-## Voting 
-
-While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)",
 periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
 
+- A vote begins when an issue with the label `call to vote` is submitted.
 - A simple majority decides the vote outcome.
-- A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub PR in dispute.
+- A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub "call to vote" issue.
 - No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
 - Voting must be open for at least one week or until the required threshold is met.
 
 ## Changes to governance
 
 <!---
-TODO: Enumerate what, precisely, constitutes a change in governance. I think it's clear editing this file, in any significant way, would count. Adjusting at least certain things wrt to the maintainer lifecycle also would likely constitute a governance change because this would directly impact who is, and is not, able to vote as well as who may be eligable or not in the future.
+TODO: Enumerate what, precisely, constitutes a change in governance. I think it's clear editing this file, in any significant way, would count. Adjusting at least certain things wrt to the maintainer lifecycle also would likely constitute a governance change because this would directly impact who is, and is not, able to vote as well as who may be eligible or not in the future.
 -->
 All changes to our governance model require a vote by the maintainers. The proposed change will be submitted as a PR against the K8sGateway community repository. Voting will proceed according to the rules established for simple conflict resolution, with the sole exception being the threshold for acceptance.
 
@@ -51,4 +51,3 @@ All changes to our governance model require a vote by the maintainers. The propo
 ## Vendor-neutrality
 
 K8sGateway is committed to [vendor-neutrality](https://contribute.cncf.io/maintainers/community/vendor-neutrality/). Our governance process has been designed to limit the influence of individual companies in furtherance of this goal.
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,7 @@ The K8sGateway project embraces the following values:
 
 Our governance builds on top of definitions from other documents, review the following files for relevant information:
 
-* [ROLES.md](./ROLES.md) for the different roles with the project.
+* [CONTRIBUTOR_LADDER.md](./CONTRIBUTOR_LADDER.md) for the different roles with the project.
 * [MAINTAINERS.md](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
 * [Code of Conduct](./CODE-OF-CONDUCT.md) for our code of conduct.
 
@@ -35,7 +35,7 @@ periodically the Maintainers may need to vote on specific actions or changes. Th
 
 * A vote begins when someone adds a PR comment containing the `/vote` command.
 * A simple majority of eligible votes decides the vote outcome.
-* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot on the GitHub PR, referring to the most recent commit when the vote is created. If there is any further commit to the PR, a new vote must be created.
+* A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the specific "vote" created by the git-vote bot on the GitHub PR, referring to the most recent commit at the time the vote is created. If there is any further commit to the PR, a new vote must be created.
 * No single company should have more than six eligible voters. It is the responsibility of each company to determine which affiliated maintainers are the eligible voters.
 * Voting must be open for at least one week or until the required threshold is met, whichever is sooner.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,54 @@
+# K8sGateway governance
+
+K8sGateway is dedicated to building a feature-rich, fast and flexible ingress controller and next-generation API gateway. This governance document details how the project is run.
+
+## Values
+
+The K8sGateway project embraces the following values:
+
+- Openness: Communication and decision-making happens in the open and is discoverable for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+- Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+- Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+- Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Roles and membership
+
+Our governance builds on top of definitions from other documents, review the following files for relevant information:
+
+- [`ROLES.md`](./ROLES.md) for the different roles with the project.
+- [`MAINTAINERS.md`](./MAINTAINERS.md) for the project maintainers, including their organizational affiliation.
+- [Code of Conduct](./CODE-OF-CONDUCT.md) for our code of conduct.
+
+
+## Voting 
+
+While most business in K8sGateway is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+periodically the Maintainers may need to vote on specific actions or changes. The following rules govern our voting process, unless otherwise stated for a specific purpose.
+
+- A simple majority decides the vote outcome.
+- A vote is cast when a project maintainer emotes thumbs-up or thumbs-down (👍 or 👎) on the GitHub PR in dispute.
+- No single company should cast more than six votes. It is the responsibility of each company to determine which affiliated maintainers will vote.
+- Voting must be open for at least one week or until the required threshold is met.
+
+## Changes to governance
+
+<!---
+TODO: Enumerate what, precisely, constitutes a change in governance. I think it's clear editing this file, in any significant way, would count. Adjusting at least certain things wrt to the maintainer lifecycle also would likely constitute a governance change because this would directly impact who is, and is not, able to vote as well as who may be eligable or not in the future.
+-->
+All changes to our governance model require a vote by the maintainers. The proposed change will be submitted as a PR against the K8sGateway community repository. Voting will proceed according to the rules established for simple conflict resolution, with the sole exception being the threshold for acceptance.
+
+- Any change requires a 2/3 super majority to be accepted.
+
+## Vendor-neutrality
+
+K8sGateway is committed to [vendor-neutrality](https://contribute.cncf.io/maintainers/community/vendor-neutrality/). Our governance process has been designed to limit the influence of individual companies in furtherance of this goal.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # K8sGateway governance
 
-K8sGateway is dedicated to building a feature-rich, fast and flexible ingress controller and next-generation API gateway. This governance document details how the project is run.
+K8sGateway is dedicated to building a feature-rich, fast and flexible next-generation API gateway. This governance document details how the project is run.
 
 ## Values
 


### PR DESCRIPTION
This is a new draft of project governance, based partially on the previous draft(#5) which was not accepted. It strives to shortcoming noticed during the first review and initial voting process. It derives more form and verbiage from upstream governance documents taking inspiration and passages from the [CNCF templates](https://github.com/cncf/project-template).