### PR TITLE
kube-style org automation

### DIFF
--- a/.github/workflows/manage-org.yaml
+++ b/.github/workflows/manage-org.yaml
@@ -1,0 +1,21 @@
+name: Manage K8sGateway Org
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - org.yaml
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout community repo
+      uses: actions/checkout@v4
+    - name: create token
+      run: |
+        echo $GH_TOK >> ./GH_TOK
+      env:
+        GH_TOK: ${{secrets.GATEWAYBOT}}
+    - name: update org
+      run: |
+        script/org/update.sh # --confirm

--- a/org.yaml
+++ b/org.yaml
@@ -59,4 +59,8 @@ orgs:
         privacy: closed
         repos:
           k8sgateway.io: maintain
-
+      notify-call-to-vote:
+        description: This team grants no permissions, it should be notified of all votes.
+        members:
+        - ilrudie
+        privacy: closed

--- a/org.yaml
+++ b/org.yaml
@@ -1,0 +1,53 @@
+orgs:
+  k8sgateway:
+    admins:
+    - ilevine
+    - ilrudie
+    - linsun
+    - nfuden
+    - sam-heilbron
+    - williamgrh
+    - yuval-k
+    members:
+    - artberger
+    - craigbox
+    - danehans
+    - jbohanon
+    - jenshu
+    - josh-pritchard
+    - kevin-shelaga
+    - lgadban
+    - Nadine2016
+    - shashankram
+    - sheidkamp
+    - Sodman
+    - stevenctl
+    teams:
+      community-maintainers:
+        description: ""
+        members:
+        - craigbox # Solo.io
+        - danehans # Solo.io
+        - ilrudie # Solo.io
+        - jenshu # Solo.io
+        - linsun # Solo.io
+        privacy: closed
+        repos:
+          community: maintain
+      controller-maintainers:
+        description: ""
+        members:
+        - danehans # Solo.io
+        - jenshu # Solo.io
+        - lgadban # Solo.io
+        - nfuden # Solo.io
+        - sam-heilbron # Solo.io
+        - shashankram # Solo.io
+        - sheidkamp # Solo.io
+        - stevenctl # Solo.io
+        - yuval-k # Solo.io
+        privacy: closed
+        repos:
+          k8sgateway: maintain
+
+

--- a/org.yaml
+++ b/org.yaml
@@ -26,28 +26,37 @@ orgs:
       community-maintainers:
         description: ""
         members:
-        - craigbox # Solo.io
-        - danehans # Solo.io
-        - ilrudie # Solo.io
-        - jenshu # Solo.io
-        - linsun # Solo.io
+        - craigbox
+        - danehans
+        - ilrudie
+        - jenshu
+        - linsun
         privacy: closed
         repos:
           community: maintain
       controller-maintainers:
         description: ""
         members:
-        - danehans # Solo.io
-        - jenshu # Solo.io
-        - lgadban # Solo.io
-        - nfuden # Solo.io
-        - sam-heilbron # Solo.io
-        - shashankram # Solo.io
-        - sheidkamp # Solo.io
-        - stevenctl # Solo.io
-        - yuval-k # Solo.io
+        - danehans
+        - jenshu
+        - lgadban
+        - nfuden
+        - sam-heilbron
+        - shashankram
+        - sheidkamp
+        - stevenctl
+        - yuval-k
         privacy: closed
         repos:
           k8sgateway: maintain
-
+      documentation-maintainers:
+        description: ""
+        members:
+        - artberger
+        - craigbox
+        - Nadine2016
+        - williamgrh
+        privacy: closed
+        repos:
+          k8sgateway.io: maintain
 

--- a/script/org/update.sh
+++ b/script/org/update.sh
@@ -23,11 +23,13 @@ readonly BIN_PATH="${REPO_ROOT}/bin"
 
 cmd="${BIN_PATH}/peribolos"
 
-# ensure peribolos is installed
-if [ ! -x "${cmd}" ]; then
-  echo "${cmd} is not executable. Trying to install."
-  GOBIN=${BIN_PATH} go install sigs.k8s.io/prow/cmd/peribolos@main
+# remove any existing peribolos, always install to prevent execution of an unintended file 
+if [ -e "${cmd}" ]; then
+  rm "${cmd}"
 fi
+
+# install peribolos
+GOBIN=${BIN_PATH} go install sigs.k8s.io/prow/cmd/peribolos@main
 
 # maybe add --ignore-invitees
 args=(

--- a/script/org/update.sh
+++ b/script/org/update.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+readonly REPO_ROOT
+
+# these org admins are required for safety!
+# peribolos requires that the user it runs as be an org admin, also for safety
+readonly org_admins=(
+  ilevine
+  ilrudie
+  linsun
+  yuval-k
+)
+
+cd "${REPO_ROOT}"
+
+readonly BIN_PATH="${REPO_ROOT}/bin"
+
+cmd="${BIN_PATH}/peribolos"
+
+# ensure peribolos is installed
+if [ ! -x "${cmd}" ]; then
+  echo "${cmd} is not executable. Trying to install."
+  GOBIN=${BIN_PATH} go install sigs.k8s.io/prow/cmd/peribolos@main
+fi
+
+# maybe add --ignore-invitees
+args=(
+  --github-token-path="${REPO_ROOT}/GH_TOK"
+  --config-path="${REPO_ROOT}/org.yaml"
+  --fix-org
+  --fix-org-members
+  --fix-teams
+  --fix-team-members
+  --fix-team-repos
+  "${org_admins[@]/#/--required-admins=}"
+)
+
+# if you are feeling brave, run this script with org:admin and add the `--confirm`
+"${cmd}" "${args[@]}" "${@}"


### PR DESCRIPTION
Working on getting [peribolos](https://docs.prow.k8s.io/docs/components/cli-tools/peribolos/) running to manage org/team membership in a similar style to Kubernetes and Istio (but ideally without any other Prow components).

Fixes #24 